### PR TITLE
backfill recordings & spruce up Archive embed

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,10 +1,7 @@
 ---
 ---
 
-@import
-  "{{ site.theme }}"
-  // , "minima/syntax-highlighting"
-;
+@import "{{ site.theme }}";
 
 $gizz-bright-green: #3d3;
 $gizz-magenta: #f39;
@@ -164,16 +161,30 @@ footer.site-footer {
   }
 
   .archive-embed {
+    width: 380px; // match iframe width attr
     margin: 1em 0;
+    border-top-left-radius: 1.5em;
+    border-top-right-radius: 1.5em;
+    box-shadow: 0 0 10px 1px #666; // 🤘
     display: flex;
     flex-direction: column;
     align-items: center;
-    width: 380px; // match iframe width attr
-    box-shadow: 0 0 10px 1px #666; // 🤘
+
     a {
-      padding: 1vmax;
-      .credit:before { content: '('; }
-      .credit:after { content: ')'; }
+      padding: 0.5em;
+      text-align: center;
+      color: #8cf;
+    }
+    .type {
+      margin-right: 0.5em;
+      border-radius: 1em;
+      padding: 0.2em 0.4em;
+      background: $gizz-yellow;
+      color: black;
+    }
+    .mic {
+      display: block;
+      &:before { content: '🎙️\a0'; }
     }
     iframe {
       height: calc(200px + 30px); // [list_height param in iframe's src] plus [height of controls bar (play/skip/volume etc) within iframe]

--- a/setlists/_posts/2022-10-10-red-rocks-amphitheatre-morrison-co.md
+++ b/setlists/_posts/2022-10-10-red-rocks-amphitheatre-morrison-co.md
@@ -3,6 +3,7 @@ layout: setlist
 date: "2022-10-10"
 venue: "Red Rocks Amphitheatre, Morrison, CO, USA"
 tour: "World Tour '22"
+title: "Red Rocks Night 1"
 ---
 
 

--- a/setlists/_posts/2022-10-10-red-rocks-amphitheatre-morrison-co.md
+++ b/setlists/_posts/2022-10-10-red-rocks-amphitheatre-morrison-co.md
@@ -82,3 +82,14 @@ Interlude music played from tape: The Land Before Timeland
 Ataraxia, Honey, The Garden Goblin, The Lord of Lightning.
 
 Pre-show song selection was One More Night (Can), Only You Know (Dion), Raining Blood (Slayer), Children of the Grave (Black Sabbath) & Sugar on My Tongue (Talking Heads).
+
+
+#### Recordings
+
+{% include archive.html type="SBD" id="kglw2022-10-10" %}
+
+{% include youtube.html author="Logan Bentley" id="wP3stlzXxDg" %}
+
+{% include youtube.html author="Kristopher Elyea" id="iE3jFflvXek" title="video of 'Evil Death Roll'" %}
+
+{% include youtube.html author="Kristopher Elyea" id="XDiSdjPu3k0" title="video of 'The Grim Reaper' and 'Planet B'" %}

--- a/setlists/_posts/2022-10-11-red-rocks-amphitheatre-morrison-co.md
+++ b/setlists/_posts/2022-10-11-red-rocks-amphitheatre-morrison-co.md
@@ -91,3 +91,14 @@ Interlude music played from tape: Hypertension
     (w/ Iron Lung tease outro)
 
 Pre-show song selection included Calypso of House by Key Tronics Ensemble, I Saw the Light by Todd Rundgren, Under Mi Sleng Teng by Wayne Smith, Milestones by Miles Davis, Tell Me What It Is by Graham Central Station, and Ramble Tamble by CCR.
+
+
+#### Recordings
+
+{% include archive.html type="SBD" id="kglw2022-10-11.rr" %}
+
+{% include youtube.html author="Logan Bentley" id="3KFJoHgAS7Y" %}
+
+{% include youtube.html author="that1skeleyton" id="0pWDFTUOOJY" %}
+
+{% include youtube.html author="atthebeach70" id="SjloISlMVY0" %}

--- a/setlists/_posts/2022-10-11-red-rocks-amphitheatre-morrison-co.md
+++ b/setlists/_posts/2022-10-11-red-rocks-amphitheatre-morrison-co.md
@@ -3,6 +3,7 @@ layout: setlist
 date: "2022-10-11"
 venue: "Red Rocks Amphitheatre, Morrison, CO, USA"
 tour: "World Tour '22"
+title: "Red Rocks Night 2"
 ---
 
 

--- a/setlists/_posts/2022-10-14-palace-theatre-st-paul-mn.md
+++ b/setlists/_posts/2022-10-14-palace-theatre-st-paul-mn.md
@@ -32,3 +32,13 @@ tour: "World Tour '22"
 
 13. The Dripping Tap
 
+
+#### Recordings
+
+{% include archive.html type="AUD" id="kg2022-10-14" credit="the lapis king" %}
+
+{% include youtube.html author="Mystery Jack" id="JH5zT3WgCgA" %}
+
+{% include youtube.html author="UnderCurrentMPLS" id="gCr0H5nv_z4" %}
+
+{% include youtube.html author="Iroquois Pliskin" id="QFEFY0fIMG0" %}

--- a/setlists/_posts/2022-10-15-radius-chicago-il.md
+++ b/setlists/_posts/2022-10-15-radius-chicago-il.md
@@ -42,3 +42,12 @@ tour: "World Tour '22"
 15. Float Along - Fill Your Lungs
 
 
+#### Recordings
+
+{% include archive.html type="AUD" id="kglw2022-10-15" credit="Teddy 'Dankski' Dunski" mic="Sony HDR-CX760V" %}
+
+{% include youtube.html author="Mystery Jack" id="PI1rqKjVBbI" %}
+
+{% include youtube.html author="tonymontana" id="3Tjac2DUK8k" %}
+
+{% include youtube.html author="Scizzardland" id="4RiWK-isn8Q" %}

--- a/setlists/_posts/2022-10-16-masonic-temple-theatre-detroit-mi.md
+++ b/setlists/_posts/2022-10-16-masonic-temple-theatre-detroit-mi.md
@@ -42,3 +42,12 @@ tour: "World Tour '22"
 15. Lava
 
 
+#### Recordings
+
+Audio: [one long file on Archive.org](https://archive.org/details/kglw2022-10-16)
+
+{% include youtube.html author="Mystery Jack" id="UZwMzla30J0" %}
+
+{% include youtube.html author="Joel Van" id="MSkeohRhKzo" %}
+
+{% include youtube.html author="LeeACDC1" id="IOCzKsrkY60" %}


### PR DESCRIPTION
back to Red Rocks night 1

<img width="439" alt="Screenshot 2023-01-22 at 4 45 51 PM" src="https://user-images.githubusercontent.com/174307/213949602-af8d6140-b9d7-43c0-a9bc-3f77e6d01663.png">
<img width="537" alt="Screenshot 2023-01-22 at 4 45 42 PM" src="https://user-images.githubusercontent.com/174307/213949604-8b8366a6-ae03-4425-9971-e353fc769139.png">
